### PR TITLE
Add appbar

### DIFF
--- a/lib/pages/forgot_password.dart
+++ b/lib/pages/forgot_password.dart
@@ -11,8 +11,21 @@ class ForgotPasswordPage extends StatelessWidget {
         create: (_) => AuthenticationService(FirebaseAuth.instance),
         child: Scaffold(
           backgroundColor: Colors.red[100],
+          appBar: AppBar(
+            title: _titleText(context),
+            elevation: 0,
+            flexibleSpace:
+                Container(decoration: BoxDecoration(color: Colors.red[100])),
+          ),
           body: ForgotPasswordScreen(),
         ));
+  }
+
+  Widget _titleText(BuildContext context) {
+    return Text(
+      'Forgot Password',
+      style: TextStyle(color: Colors.white, fontSize: HEADING_FONT_SIZE),
+    );
   }
 }
 
@@ -52,15 +65,6 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
         _submitEnabled = !_submitEnabled;
       });
     }
-  }
-
-  Widget _titleText(BuildContext context) {
-    return Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          'Forgot Password',
-          style: TextStyle(color: Colors.white, fontSize: HEADING_FONT_SIZE),
-        ));
   }
 
   Widget _descriptionText(BuildContext context) {
@@ -163,10 +167,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
 
   @override
   Widget build(BuildContext context) {
-    List<Widget> contents = <Widget>[
-      _titleText(context),
-      SizedBox(height: 36),
-    ];
+    List<Widget> contents = <Widget>[];
 
     if (_emailSent) {
       contents.addAll(

--- a/lib/pages/signup.dart
+++ b/lib/pages/signup.dart
@@ -11,8 +11,21 @@ class SignupPage extends StatelessWidget {
         create: (_) => AuthenticationService(FirebaseAuth.instance),
         child: Scaffold(
           backgroundColor: Colors.teal[100],
+          appBar: AppBar(
+            title: _titleText(context),
+            elevation: 0,
+            flexibleSpace:
+                Container(decoration: BoxDecoration(color: Colors.teal[100])),
+          ),
           body: SignupScreen(),
         ));
+  }
+
+  Widget _titleText(BuildContext context) {
+    return Text(
+      'Create Account',
+      style: TextStyle(color: Colors.white, fontSize: HEADING_FONT_SIZE),
+    );
   }
 }
 
@@ -58,15 +71,6 @@ class _SignupScreenState extends State<SignupScreen> {
         _submitEnabled = !_submitEnabled;
       });
     }
-  }
-
-  Widget _welcomeText(BuildContext context) {
-    return Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          'Create An Account',
-          style: TextStyle(color: Colors.white, fontSize: HEADING_FONT_SIZE),
-        ));
   }
 
   Widget _emailInput(BuildContext context) {
@@ -210,8 +214,6 @@ class _SignupScreenState extends State<SignupScreen> {
                 padding: EdgeInsets.all(24.0),
                 child: Column(
                   children: <Widget>[
-                    _welcomeText(context),
-                    SizedBox(height: 36),
                     _emailInput(context),
                     SizedBox(height: 12),
                     _passwordInput(context),


### PR DESCRIPTION
Adding AppBar For
-
- `Forgot Password` page
- `Create Account` page

Purpose
-
- iOS devices didn't show a back button when on the pages listed above. Adding AppBar allows for a back button to be added and user is no longer stuck on those pages.

Pictures of New Feature
- 
![Forgot-Password](https://user-images.githubusercontent.com/32799231/105792129-15f26c80-5f55-11eb-8152-1aa456920d47.png)
![Create-Account](https://user-images.githubusercontent.com/32799231/105792289-4c2fec00-5f55-11eb-8203-5e043d790894.png)


